### PR TITLE
Revert "Pin specific dependencies versions"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,11 +53,11 @@ setup(
     license='Copyright (C) VAST Data Ltd.',
     packages=find_packages(),
     install_requires=[
-        'flatbuffers==2.0.0',
-        'pyarrow==6.0.1',
-        'requests==2.24.0',
-        'aws-requests-auth==0.4.3',
-        'xmltodict==0.13.0',
+        'flatbuffers',
+        'pyarrow',
+        'requests',
+        'aws-requests-auth',
+        'xmltodict',
         'protobuf==3.19.6'
     ],
     long_description=long_description,


### PR DESCRIPTION
This reverts commit 85a196a87cbc5c0ae6f0c93d0c6bb311cdcdc855.

Fixes https://github.com/vast-data/vastdb_sdk/issues/15