### PR TITLE
Fix transaction commit in `VastdbApi.insert()`

### DIFF
--- a/vastdb/api.py
+++ b/vastdb/api.py
@@ -2066,10 +2066,11 @@ class VastdbApi:
                 for future in concurrent.futures.as_completed(futures):
                     result.extend(future.result()) # trigger an exception if occurred in any thread
 
-            return result
             # commit if needed
             if created_txid:
                 self.commit_transaction(txid)
+
+            return result
 
         except Exception as e:
             _logger.exception('exception occurred')


### PR DESCRIPTION
Introduced in fd1d47bcc605cdac637f0ba2becbb426bd792b53.