### PR TITLE
Clarify the catalog example

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,18 +176,27 @@ batches = snaps[0].schema('schema-name').table('table-name').select()
 [VAST Catalog](https://vastdata.com/blog/vast-catalog-treat-your-file-system-like-a-database) can be queried as a regular table:
 
 ```python
-table = pa.Table.from_batches(tx.catalog.select(['element_type']))
-df = table.to_pandas()
+import pyarrow as pa
+import vastdb
 
-total_elements = len(df)
-print(f"Total elements in the catalog: {total_elements}")
+session = vastdb.connect(
+    endpoint='http://vip-pool.v123-xy.VastENG.lab',
+    access=AWS_ACCESS_KEY_ID,
+    secret=AWS_SECRET_ACCESS_KEY)
 
-file_count = (df['element_type'] == 'FILE').sum()
-print(f"Number of files/objects: {file_count}")
+with session.transaction() as tx:
+    table = pa.Table.from_batches(tx.catalog.select(['element_type']))
+    df = table.to_pandas()
 
-distinct_elements = df['element_type'].unique()
-print("Distinct element types on the system:")
-print(distinct_elements)
+    total_elements = len(df)
+    print(f"Total elements in the catalog: {total_elements}")
+
+    file_count = (df['element_type'] == 'FILE').sum()
+    print(f"Number of files/objects: {file_count}")
+
+    distinct_elements = df['element_type'].unique()
+    print("Distinct element types on the system:")
+    print(distinct_elements)
 ```
 
 See the following blog posts for more examples:


### PR DESCRIPTION
Clarify the catalog example by including the import and connection within it. I was helping a customer today and both the customer and SE stumbled over having the connection happening outside of the catalog example as their only use-case for the library is the catalog.

Most of the diff is indenting the prior code so best reviewed ignoring whitespace.