### PR TITLE
Fix version() by fixing importlib import

### DIFF
--- a/vastdb/__init__.py
+++ b/vastdb/__init__.py
@@ -13,5 +13,5 @@ def connect(*args, **kwargs):  # noqa: D103
 
 def version():
     """Return VAST DB SDK version."""
-    import importlib
+    import importlib.metadata
     return importlib.metadata.distribution(__package__).version


### PR DESCRIPTION
`vastdb.version()` is currently broken because we're not importing the right module before using it.