### PR TITLE
fix: support to Python version 3.14 in CI and documentation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,7 +44,7 @@ build:
 
   parallel:
     matrix:
-      - PYTHON_VERSION: ['3.10', '3.11', '3.12', '3.13']
+      - PYTHON_VERSION: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
 
 test_orion [branch]:
@@ -67,7 +67,7 @@ upload_to_artifactory:
     - vast-dev-builder
 
   variables:
-    PYSDK_IMAGE: ${PYSDK_IMAGE_PREFIX}-3.13 # use latest Python image for deployment
+    PYSDK_IMAGE: ${PYSDK_IMAGE_PREFIX}-3.14 # use latest Python image for deployment
 
   script:
   - echo "Publishing artifacts from $PYSDK_IMAGE..."
@@ -88,7 +88,7 @@ upload_to_pypi:
     - vast-dev-builder
 
   variables:
-    PYSDK_IMAGE: ${PYSDK_IMAGE_PREFIX}-3.13 # use latest Python image for deployment
+    PYSDK_IMAGE: ${PYSDK_IMAGE_PREFIX}-3.14 # use latest Python image for deployment
 
   when: manual
   rules:
@@ -128,7 +128,7 @@ keep_latest_dev:
 
   parallel:
     matrix:
-      - PYTHON_VERSION: ['3.10', '3.11', '3.12', '3.13']
+      - PYTHON_VERSION: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
 
 # Keep images of released SDK versions available (so we can run them from Orion's CI on demand)
@@ -155,4 +155,4 @@ keep_latest_release:
 
   parallel:
     matrix:
-      - PYTHON_VERSION: ['3.10', '3.11', '3.12', '3.13']
+      - PYTHON_VERSION: ['3.10', '3.11', '3.12', '3.13', '3.14']

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For technical details about VAST Database architecture, see the [whitepaper](htt
 
 ### Requirements
 
-- Linux client with Python 3.10 - 3.13, and network access to the VAST Cluster
+- Linux client with Python 3.10 - 3.14, and network access to the VAST Cluster
 - [Virtual IP pool configured with DNS service](https://support.vastdata.com/s/topic/0TOV40000000FThOAM/configuring-network-access-v50)
 - [S3 access & secret keys on the VAST cluster](https://support.vastdata.com/s/article/UUID-4d2e7e23-b2fb-7900-d98f-96c31a499626)
 - [Tabular identity policy with the proper permissions](https://support.vastdata.com/s/article/UUID-14322b60-d6a2-89ac-3df0-3dfbb6974182)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aws-requests-auth
 ibis-framework~=10.1
-pyarrow~=18.0
+pyarrow>=18.0
 pyarrow-hotfix==0.7
 flatbuffers
 packaging

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Topic :: Database',
         'Topic :: Database :: Front-Ends',
     ],


### PR DESCRIPTION
- pyarrow have wheels for 3.14 just starting at version 22, loosened the requirement version to have it pass the tests also for 3.14